### PR TITLE
Fix link to issue creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Please consider citing our paper if you use our code in your project.
 This repository is openly developed in the wild and contributions (both internal and external) are highly appreciated.
 See [CONTRIBUTING.md](./CONTRIBUTING.md) on how to get started.
 
-If you have feedback or want to propose a new feature, please [open an issue](https://github.com/porscheofficial/porscheofficial.github.io/issues).
+If you have feedback or want to propose a new feature, please [open an issue](https://github.com/porscheofficial/distribution_and_volume_based_isolation_forest/issues).
 Thank you! 😊
 
 ## Acknowledgements


### PR DESCRIPTION
Hey team,

I just spotted an unintended link that refers to the issue creation tab of the Porsche Open Source Platform. While I was here, I left a PR for you :)

Best regards,

Eduard

## ✅ Checks
- [X] I have read and accept the [Contributor License Agreement](https://opensource.porsche.com/docs/cla)
